### PR TITLE
Silence warnings

### DIFF
--- a/rtc.c
+++ b/rtc.c
@@ -26,13 +26,13 @@
 #include "errors.h"
 
 /* pointers to the compare/ovf hooks */
-void (*cmp_fn)() = NULL;
-void (*ovf_fn)() = NULL;
+void (*cmp_fn)(void) = NULL;
+void (*ovf_fn)(void) = NULL;
 
 /* FIXME: unsure if the syncbusy checking is in the right places */
 
 /* init the RTC */
-int rtc_init(uint16_t period, void (*cmp_hook)(), void (*ovf_hook)()) {
+int rtc_init(uint16_t period, void (*cmp_hook)(void), void (*ovf_hook)(void)) {
     RTC.PER = period;
     RTC.CNT = 0;
     /* ensure it's all written before we exit */

--- a/rtc.h
+++ b/rtc.h
@@ -54,7 +54,7 @@ typedef enum {
  *  \param ovf_ev Event channel to strobe on overflow, -1 is none
  *  \return 0 on success, errors.h otherwise
  */
-int rtc_init(uint16_t period, void (*cmp_hook)(), void (*ovf_hook)());
+int rtc_init(uint16_t period, void (*cmp_hook)(void), void (*ovf_hook)(void));
 
 /** \brief Clock the RTC at the given divisor.
  *

--- a/timer.c
+++ b/timer.c
@@ -54,7 +54,7 @@ typedef struct {
 #endif
  	} hw;
  	void (*cmp_fn)(uint8_t); /**< pointer to a compare hook, for channel n */
- 	void (*ovf_fn)(); /**< pointer to a top hook for whole timer */
+ 	void (*ovf_fn)(void); /**< pointer to a top hook for whole timer */
 } timer_t;
 
 /* global timer constructs */
@@ -68,7 +68,7 @@ void _timer_cmp_hook(uint8_t num, uint8_t ch);
 
 /* init the struct, and some asic stuff about the timer */
 int timer_init(uint8_t timernum, timer_pwm_t mode, uint16_t period,
-					void (*cmp_hook)(uint8_t), void (*ovf_hook)()) {
+					void (*cmp_hook)(uint8_t), void (*ovf_hook)(void)) {
 	if (timernum >= MAX_TIMERS) {
 		return -ENODEV;
 	}
@@ -764,7 +764,7 @@ int timer_count(uint8_t timernum, uint16_t value) {
 /* ovf handler */
 void _timer_ovf_hook(uint8_t num) {
 	if (timers[num] && timers[num]->ovf_fn) {
-		(*(timers[num]->ovf_fn))(NULL);
+		(*(timers[num]->ovf_fn))();
 	}
 }
 

--- a/timer.h
+++ b/timer.h
@@ -299,7 +299,7 @@ typedef enum {
  *  \param ovf_hook Function to invoke on overflow
  *  \return 0 on success, errors.h otherwise */
 int timer_init(timer_portname_t timer, timer_pwm_t mode, uint16_t period,
-				void (*cmp_hook)(uint8_t), void (*ovf_hook)());
+				void (*cmp_hook)(uint8_t), void (*ovf_hook)(void));
 
 /** \brief Clock the timer from the given source
  *


### PR DESCRIPTION
This appears to silence the compiler warnings around the function pointer arguments.
